### PR TITLE
Fixing `wiredTigerCacheSizeGB` issue during global initialization of mongodb pods.

### DIFF
--- a/database/mongo.statefulset.yaml
+++ b/database/mongo.statefulset.yaml
@@ -50,7 +50,7 @@ spec:
             - "--interleave=all"
             - "mongod"
             - "--wiredTigerCacheSizeGB"
-            - "0.1"
+            - "0.25"
             - "--bind_ip"
             - "0.0.0.0"
             - "--replSet"


### PR DESCRIPTION
This is causing an issue during pod creation when we execute `kubectl apply -f database/mongo.statefulset.yaml`. If you check `mongo-0` pod logs using `kubectl logs mongo-0`, you'd see this error:

```
{"t":{"$date":"2021-09-04T16:43:04.496Z"},"s":"F",  "c":"CONTROL",  "id":20574,   "ctx":"-","msg":"Error during global initialization","attr":{"error":{"code":2,"codeName":"BadValue","errmsg":"storage.wiredTiger.engineConfig.cacheSizeGB must be greater than or equal to 0.25"}}}
```

This PR fixes the issue by setting `0.25` as `--wiredTigerCacheSizeGB` value.